### PR TITLE
Refactor form validation

### DIFF
--- a/src/Components/FormInput.js
+++ b/src/Components/FormInput.js
@@ -2,20 +2,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-function FormInput({
-  children,
-  disabled,
-  label,
-  onChange,
-  isWrapped,
-  property,
-  required,
-  showRequiredHint,
-  size,
-  type,
-  unit,
-  value,
-}) {
+function FormInput({ children, disabled, label, onChange, isWrapped, property, required, showRequiredHint, size, type, unit, value }) {
   const [focused, setFocused] = useState(false);
 
   function typedValue(stringValue) {

--- a/src/Components/FormInput.scss
+++ b/src/Components/FormInput.scss
@@ -1,0 +1,8 @@
+.forminput__error {
+  background-color: hsl(0, 53%, 88%);
+  height: 88px;
+  position: relative;
+  left: -25px;
+  padding: 2%;
+  width: 513px;
+}

--- a/src/EMS/PatientFields.js
+++ b/src/EMS/PatientFields.js
@@ -20,12 +20,12 @@ function PatientFields({ ringdown, onChange }) {
     ringdown.fixedFields = invalidValidStatus[1];
 
     for (let i = 0; i < invalidValidStatus[0].length; i += 1) {
-      const validator = `${invalidValidStatus[0][i]  }Validator`;
-      ringdown[validator] = `${invalidValidStatus[0][i]  }_red`;
+      const validator = `${invalidValidStatus[0][i]}Validator`;
+      ringdown[validator] = `${invalidValidStatus[0][i]}_red`;
     }
     for (let i = 0; i < invalidValidStatus[1].length; i += 1) {
-      const validator = `${invalidValidStatus[1][i]  }Validator`;
-      ringdown[validator] = `${invalidValidStatus[1][i]  }_fixed`;
+      const validator = `${invalidValidStatus[1][i]}Validator`;
+      ringdown[validator] = `${invalidValidStatus[1][i]}_fixed`;
     }
 
     setChangeStatus(!changeStatus);
@@ -36,7 +36,7 @@ function PatientFields({ ringdown, onChange }) {
         <Heading title="Unit Info" />
         <div className="usa-accordion__content">
           <fieldset className="usa-fieldset">
-            <div className={ringdown.ambulanceIdentifierValidator}>
+            <div className={ringdown.ambulanceIdentifierValidator} onClick={() => handleClick('ambulanceIdentifier')}>
               <FormInput
                 label="Unit #"
                 onChange={onChange}
@@ -86,7 +86,11 @@ function PatientFields({ ringdown, onChange }) {
             </div>
           </fieldset>
           <fieldset className="usa-fieldset">
-            <div role="alert" className={ringdown.emergencyServiceResponseTypeValidator} onClick={() => handleClick('emergencyServiceResponseType')}>
+            <div
+              role="alert"
+              className={ringdown.emergencyServiceResponseTypeValidator}
+              onClick={() => handleClick('emergencyServiceResponseType')}
+            >
               <label className="usa-label usa-label--required" htmlFor="emergencyServiceResponseType">
                 Urgency
               </label>
@@ -107,14 +111,18 @@ function PatientFields({ ringdown, onChange }) {
             </div>
           </fieldset>
           <fieldset className="usa-fieldset">
-            <FormTextArea
-              label="Chief Complaint"
-              onChange={onChange}
-              property="chiefComplaintDescription"
-              value={ringdown.chiefComplaintDescription}
-            />
-            <div className="usa-hint usa-hint--important">
-              <i className="fas fa-info-circle" /> Exclude identifying information.
+            <div
+              role="alert"
+              className={ringdown.chiefComplaintDescriptionValidator}
+              onClick={() => handleClick('chiefComplaintDescription')}
+            >
+              <label className="usa-label usa-label--required" htmlFor="chiefComplaintDescription">
+                Chief Complaint
+              </label>
+              <FormTextArea label="" onChange={onChange} property="chiefComplaintDescription" value={ringdown.chiefComplaintDescription} />
+              <div className="usa-hint usa-hint--important">
+                <i className="fas fa-info-circle" /> Exclude identifying information.
+              </div>
             </div>
           </fieldset>
           <fieldset className="usa-fieldset">
@@ -139,149 +147,157 @@ function PatientFields({ ringdown, onChange }) {
             </div>
           </fieldset>
         </div>
-        <Heading title="Vitals" subtitle="(optional)" />
-        <div className="usa-accordion__content">
-          <fieldset className="usa-fieldset">
-            <FormInput
-              label="Blood Pressure"
-              onChange={onChange}
-              property="systolicBloodPressure"
-              size="small"
-              type="number"
-              unit="/"
-              value={ringdown.systolicBloodPressure}
-            >
-              &nbsp;&nbsp;
+        <div type="alert" onClick={() => handleClick('end')}>
+          <Heading title="Vitals" subtitle="(optional)" />
+          <div className="usa-accordion__content">
+            <fieldset className="usa-fieldset">
               <FormInput
+                label="Blood Pressure"
                 onChange={onChange}
-                isWrapped={false}
-                property="diastolicBloodPressure"
+                property="systolicBloodPressure"
                 size="small"
                 type="number"
-                unit="mmHg"
-                value={ringdown.diastolicBloodPressure}
-              />
-            </FormInput>
-            <FormInput
-              label="Pulse"
-              onChange={onChange}
-              property="heartRateBpm"
-              size="small"
-              type="number"
-              unit="bpm"
-              value={ringdown.heartRateBpm}
-            />
-            <FormInput
-              label="Respiratory Rate"
-              onChange={onChange}
-              property="respiratoryRate"
-              size="small"
-              type="number"
-              unit="breath/m"
-              value={ringdown.respiratoryRate}
-            />
-            <FormInput
-              label="SpO2"
-              onChange={onChange}
-              property="oxygenSaturation"
-              size="small"
-              type="number"
-              unit="%"
-              value={ringdown.oxygenSaturation}
-            />
-            <div className="padding-left-4">
-              <FormRadio
-                currentValue={ringdown.lowOxygenResponseType}
-                disabled={ringdown.oxygenSaturation === null || ringdown.oxygenSaturation === ''}
-                label="RA"
+                unit="/"
+                value={ringdown.systolicBloodPressure}
+              >
+                &nbsp;&nbsp;
+                <FormInput
+                  onChange={onChange}
+                  isWrapped={false}
+                  property="diastolicBloodPressure"
+                  size="small"
+                  type="number"
+                  unit="mmHg"
+                  value={ringdown.diastolicBloodPressure}
+                />
+              </FormInput>
+              <FormInput
+                label="Pulse"
                 onChange={onChange}
-                property="lowOxygenResponseType"
-                value="ROOM AIR"
+                property="heartRateBpm"
+                size="small"
+                type="number"
+                unit="bpm"
+                value={ringdown.heartRateBpm}
               />
-              <div className="display-flex flex-row flex-align-center margin-top-2">
+              <FormInput
+                label="Respiratory Rate"
+                onChange={onChange}
+                property="respiratoryRate"
+                size="small"
+                type="number"
+                unit="breath/m"
+                value={ringdown.respiratoryRate}
+              />
+              <FormInput
+                label="SpO2"
+                onChange={onChange}
+                property="oxygenSaturation"
+                size="small"
+                type="number"
+                unit="%"
+                value={ringdown.oxygenSaturation}
+              />
+              <div className="padding-left-4">
                 <FormRadio
                   currentValue={ringdown.lowOxygenResponseType}
                   disabled={ringdown.oxygenSaturation === null || ringdown.oxygenSaturation === ''}
-                  label="O2"
+                  label="RA"
                   onChange={onChange}
                   property="lowOxygenResponseType"
-                  value="SUPPLEMENTAL OXYGEN"
+                  value="ROOM AIR"
                 />
-                <div className="margin-left-4">
-                  <FormInput
-                    disabled={ringdown.lowOxygenResponseType !== 'SUPPLEMENTAL OXYGEN'}
+                <div className="display-flex flex-row flex-align-center margin-top-2">
+                  <FormRadio
+                    currentValue={ringdown.lowOxygenResponseType}
+                    disabled={ringdown.oxygenSaturation === null || ringdown.oxygenSaturation === ''}
+                    label="O2"
                     onChange={onChange}
-                    property="supplementalOxygenAmount"
-                    size="small"
-                    type="number"
-                    unit="L"
-                    value={ringdown.supplementalOxygenAmount}
+                    property="lowOxygenResponseType"
+                    value="SUPPLEMENTAL OXYGEN"
                   />
+                  <div className="margin-left-4">
+                    <FormInput
+                      disabled={ringdown.lowOxygenResponseType !== 'SUPPLEMENTAL OXYGEN'}
+                      onChange={onChange}
+                      property="supplementalOxygenAmount"
+                      size="small"
+                      type="number"
+                      unit="L"
+                      value={ringdown.supplementalOxygenAmount}
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-            <FormInput
-              label="Temp."
-              onChange={onChange}
-              property="temperature"
-              size="small"
-              type="number"
-              unit="&deg;F"
-              value={ringdown.temperature}
-            />
-          </fieldset>
-        </div>
-        <Heading title="Additional notes" subtitle="(optional)" />
-        <div className="usa-accordion__content">
-          <fieldset className="usa-fieldset">
-            <FormCheckbox
-              currentValue={ringdown.etohSuspectedIndicator}
-              label="ETOH suspected"
-              onChange={onChange}
-              property="etohSuspectedIndicator"
-              value={true}
-            />
-            <FormCheckbox
-              currentValue={ringdown.drugsSuspectedIndicator}
-              label="Drugs suspected"
-              onChange={onChange}
-              property="drugsSuspectedIndicator"
-              value={true}
-            />
-            <FormCheckbox
-              currentValue={ringdown.psychIndicator}
-              label="Psych patient"
-              onChange={onChange}
-              property="psychIndicator"
-              value={true}
-            />
-            <FormCheckbox
-              currentValue={ringdown.combativeBehaviorIndicator}
-              label="Combative"
-              onChange={onChange}
-              property="combativeBehaviorIndicator"
-              value={true}
-            />
-            <div className="padding-left-4">
-              <FormCheckbox
-                currentValue={ringdown.restraintIndicator}
-                disabled={ringdown.combativeBehaviorIndicator !== true}
-                label="4-point restraint"
+              <FormInput
+                label="Temp."
                 onChange={onChange}
-                property="restraintIndicator"
+                property="temperature"
+                size="small"
+                type="number"
+                unit="&deg;F"
+                value={ringdown.temperature}
+              />
+            </fieldset>
+          </div>
+          <Heading title="Additional notes" subtitle="(optional)" />
+          <div className="usa-accordion__content">
+            <fieldset className="usa-fieldset">
+              <FormCheckbox
+                currentValue={ringdown.etohSuspectedIndicator}
+                label="ETOH suspected"
+                onChange={onChange}
+                property="etohSuspectedIndicator"
                 value={true}
               />
-            </div>
-            <FormCheckbox
-              currentValue={ringdown.covid19SuspectedIndicator}
-              label="COVID-19 suspected"
-              onChange={onChange}
-              property="covid19SuspectedIndicator"
-              value={true}
-            />
-            <FormCheckbox currentValue={ringdown.ivIndicator} label="IV started" onChange={onChange} property="ivIndicator" value={true} />
-            <FormTextArea label="Other" onChange={onChange} property="otherObservationNotes" value={ringdown.otherObservationNotes} />
-          </fieldset>
+              <FormCheckbox
+                currentValue={ringdown.drugsSuspectedIndicator}
+                label="Drugs suspected"
+                onChange={onChange}
+                property="drugsSuspectedIndicator"
+                value={true}
+              />
+              <FormCheckbox
+                currentValue={ringdown.psychIndicator}
+                label="Psych patient"
+                onChange={onChange}
+                property="psychIndicator"
+                value={true}
+              />
+              <FormCheckbox
+                currentValue={ringdown.combativeBehaviorIndicator}
+                label="Combative"
+                onChange={onChange}
+                property="combativeBehaviorIndicator"
+                value={true}
+              />
+              <div className="padding-left-4">
+                <FormCheckbox
+                  currentValue={ringdown.restraintIndicator}
+                  disabled={ringdown.combativeBehaviorIndicator !== true}
+                  label="4-point restraint"
+                  onChange={onChange}
+                  property="restraintIndicator"
+                  value={true}
+                />
+              </div>
+              <FormCheckbox
+                currentValue={ringdown.covid19SuspectedIndicator}
+                label="COVID-19 suspected"
+                onChange={onChange}
+                property="covid19SuspectedIndicator"
+                value={true}
+              />
+              <FormCheckbox
+                currentValue={ringdown.ivIndicator}
+                label="IV started"
+                onChange={onChange}
+                property="ivIndicator"
+                value={true}
+              />
+              <FormTextArea label="Other" onChange={onChange} property="otherObservationNotes" value={ringdown.otherObservationNotes} />
+            </fieldset>
+          </div>
         </div>
       </div>
     </>

--- a/src/EMS/PatientFields.js
+++ b/src/EMS/PatientFields.js
@@ -79,7 +79,7 @@ function PatientFields({ ringdown, onChange }) {
     //  - if status was ERROR or FIXED, no need to do anything
     const partition = updatedData[updatedField].order - 1;
     const sorted = Object.values(updatedData).sort(ascendingByOrder);
-    for (let i = partition; i >= 0; i--) {
+    for (let i = partition; i >= 0; i -= 1) {
       if (sorted[i].inputState === InputState.NO_INPUT) {
         const fieldName = sorted[i].name;
         updatedData[fieldName].inputState = InputState.ERROR;

--- a/src/EMS/PatientFields.js
+++ b/src/EMS/PatientFields.js
@@ -47,7 +47,7 @@ function ascendingByOrder(a, b) {
 function PatientFields({ ringdown, onChange }) {
   const [changeStatus, setChangeStatus] = useState(false);
 
-  const [fieldData, setFieldData] = useState({
+  const [validationData, setValidationData] = useState({
     ambulanceIdentifier: new PatientFieldData('ambulanceIdentifier', 0, InputState.NO_INPUT),
     dispatchCallNumber: new PatientFieldData('dispatchCallNumber', 1, InputState.NO_INPUT),
     age: new PatientFieldData('age', 2, InputState.NO_INPUT),
@@ -93,15 +93,12 @@ function PatientFields({ ringdown, onChange }) {
    * @param {*} updatedField the field that was interacted with
    */
   function handleUserInput(updatedField, inputValue) {
-    console.log(`UPDATED FIELD IS ${updatedField}`);
-    console.log(`INPUT VALUE IS ${inputValue}`);
     // call the callback passed in from the parent component
     onChange();
 
     // update field states
-    const updatedData = updateFieldData(updatedField, fieldData);
-    console.log(`UPDATED FIELD DATA IS \n ${JSON.stringify(updatedData)}`);
-    setFieldData(updatedData);
+    const updatedData = updateFieldData(updatedField, validationData);
+    setValidationData(updatedData);
   }
 
   /**
@@ -146,7 +143,7 @@ function PatientFields({ ringdown, onChange }) {
         <Heading title="Unit Info" />
         <div className="usa-accordion__content">
           <fieldset className="usa-fieldset">
-            <div className={stateToClassName(fieldData.ambulanceIdentifier.inputState)}>
+            <div className={stateToClassName(validationData.ambulanceIdentifier.inputState)}>
               <FormInput
                 label="Unit #"
                 onChange={handleUserInput}
@@ -156,7 +153,7 @@ function PatientFields({ ringdown, onChange }) {
                 value={ringdown.ambulanceIdentifier}
               />
             </div>
-            <div role="alert" className={stateToClassName(fieldData.dispatchCallNumber.inputState)}>
+            <div role="alert" className={stateToClassName(validationData.dispatchCallNumber.inputState)}>
               <FormInput
                 label="Incident #"
                 onChange={handleUserInput}
@@ -172,7 +169,7 @@ function PatientFields({ ringdown, onChange }) {
         <Heading title="Patient Info" />
         <div className="usa-accordion__content">
           <fieldset className="usa-fieldset">
-            <div role="alert" className={stateToClassName(fieldData.age.inputState)}>
+            <div role="alert" className={stateToClassName(validationData.age.inputState)}>
               <FormInput
                 label="Age (estim.)"
                 onChange={handleUserInput}

--- a/src/EMS/PatientFields.scss
+++ b/src/EMS/PatientFields.scss
@@ -1,3 +1,12 @@
+.patientfields__form-error {
+  background-color: hsl(0, 53%, 88%);
+  height: 88px;
+  position: relative;
+  left: -25px;
+  padding: 2%;
+  width: 513px;
+}
+
 .ambulanceIdentifier_red {
   background-color: hsl(0, 53%, 88%);
   height: 88px;
@@ -6,6 +15,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .ambulanceIdentifier_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 88px;
@@ -14,7 +24,7 @@
   padding: 2%;
   width: 513px;
 }
-///
+
 .dispatchCallNumber_red {
   background-color: hsl(0, 53%, 88%);
   height: 88px;
@@ -23,6 +33,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .dispatchCallNumber_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 88px;
@@ -31,6 +42,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .age_red {
   background-color: hsl(0, 53%, 88%);
   height: 88px;
@@ -39,6 +51,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .age_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 88px;
@@ -47,6 +60,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .sex_red {
   background-color: hsl(0, 53%, 88%);
   height: 196px;
@@ -55,6 +69,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .sex_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 196px;
@@ -63,6 +78,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .emergencyServiceResponseType_red {
   background-color: hsl(0, 53%, 88%);
   height: 147px;
@@ -71,6 +87,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .emergencyServiceResponseType_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 147px;
@@ -79,6 +96,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .chiefComplaintDescription_red {
   background-color: hsl(0, 53%, 88%);
   height: 282px;
@@ -87,6 +105,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .chiefComplaintDescription_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 282px;
@@ -95,6 +114,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .stableIndicator_red {
   background-color: hsl(0, 53%, 88%);
   height: 151px;
@@ -103,6 +123,7 @@
   padding: 2%;
   width: 513px;
 }
+
 .stableIndicator_fixed {
   background-color: hsl(124, 54%, 88%);
   height: 151px;

--- a/src/EMS/PatientFields.scss
+++ b/src/EMS/PatientFields.scss
@@ -79,9 +79,25 @@
   padding: 2%;
   width: 513px;
 }
+.chiefComplaintDescription_red {
+  background-color: hsl(0, 53%, 88%);
+  height: 282px;
+  position: relative;
+  left: -25px;
+  padding: 2%;
+  width: 513px;
+}
+.chiefComplaintDescription_fixed {
+  background-color: hsl(124, 54%, 88%);
+  height: 282px;
+  position: relative;
+  left: -25px;
+  padding: 2%;
+  width: 513px;
+}
 .stableIndicator_red {
   background-color: hsl(0, 53%, 88%);
-  height: 88px;
+  height: 151px;
   position: relative;
   left: -25px;
   padding: 2%;
@@ -89,7 +105,7 @@
 }
 .stableIndicator_fixed {
   background-color: hsl(124, 54%, 88%);
-  height: 88px;
+  height: 151px;
   position: relative;
   left: -25px;
   padding: 2%;

--- a/src/Models/Ringdown.js
+++ b/src/Models/Ringdown.js
@@ -324,11 +324,21 @@ class Ringdown {
       this.sex !== '' &&
       this.emergencyServiceResponseType !== null &&
       this.emergencyServiceResponseType !== '' &&
-      // this.chiefComplaintDescription !== null &&
-      // this.chiefComplaintDescription !== '' &&
+      this.chiefComplaintDescription !== null &&
+      this.chiefComplaintDescription !== '' &&
       this.stableIndicator !== null
     );
   }
+
+  get isValid() {
+    return this.isPatientValid && this.hospitalId !== null && this.etaMinutes !== null;
+  }
+
+  toJSON() {
+    return this.payload;
+  }
+
+  // form validation
 
   get formValidation() {
     return this.payload.formValidation;
@@ -340,6 +350,20 @@ class Ringdown {
 
   set currentField(value) {
     this.payload.formValidation.currentField = value;
+  }
+
+  get stop() {
+    if (!this.payload.formValidation.stop){
+      this.payload.formValidation.stop = 0
+    }
+    return this.payload.formValidation.stop;
+  }
+
+  set stop(value) {
+    console.log("stop value", value);
+    if (this.stop < value) {
+      this.payload.formValidation.stop = value;
+    } 
   }
 
   get missingFields() {
@@ -398,6 +422,14 @@ class Ringdown {
     return this.payload.formValidation.emergencyServiceResponseTypeValidator;
   }
 
+  set chiefComplaintDescriptionValidator(value) {
+    this.payload.formValidation.chiefComplaintDescriptionValidator = value;
+  }
+
+  get chiefComplaintDescriptionValidator() {
+    return this.payload.formValidation.chiefComplaintDescriptionValidator;
+  }
+
   set stableIndicatorValidator(value) {
     this.payload.formValidation.stableIndicatorValidator = value;
   }
@@ -417,20 +449,33 @@ class Ringdown {
       this.age,
       this.sex,
       this.emergencyServiceResponseType,
+      this.chiefComplaintDescription,
       this.stableIndicator,
     ];
-    const fieldNames = ['ambulanceIdentifier', 'dispatchCallNumber', 'age', 'sex', 'emergencyServiceResponseType', 'stableIndicator'];
+    const fieldNames = [
+      'ambulanceIdentifier',
+      'dispatchCallNumber',
+      'age',
+      'sex',
+      'emergencyServiceResponseType',
+      'chiefComplaintDescription',
+      'stableIndicator',
+    ];
     const fieldPosition = {
       ambulanceIdentifier: 0,
       dispatchCallNumber: 1,
       age: 2,
       sex: 3,
       emergencyServiceResponseType: 4,
-      stableIndicator: 5,
+      chiefComplaintDescription: 5,
+      stableIndicator: 6,
+      end: 7,
     };
-    const stop = fieldPosition[this.currentField];
+    this.stop = fieldPosition[this.currentField];
+    console.log("stop", this.stop, fieldPosition[this.currentField]);
 
-    for (let i = 0; i < stop; i += 1) {
+    for (let i = 0; i < this.stop; i += 1) {
+      console.log('fields', fields[i], i);
       if (fields[i]) {
         for (let j = 0; j < missingFields.length; j += 1) {
           if (missingFields[j] === fieldNames[i]) {
@@ -439,18 +484,12 @@ class Ringdown {
           }
         }
       } else if (!missingFields.includes(fieldNames[i])) {
+        console.log(missingFields);
         missingFields.push(fieldNames[i]);
       }
     }
+    console.log(missingFields);
     return [missingFields, fixedMissing];
-  }
-
-  get isValid() {
-    return this.isPatientValid && this.hospitalId !== null && this.etaMinutes !== null;
-  }
-
-  toJSON() {
-    return this.payload;
   }
 }
 

--- a/src/Models/Ringdown.js
+++ b/src/Models/Ringdown.js
@@ -353,17 +353,17 @@ class Ringdown {
   }
 
   get stop() {
-    if (!this.payload.formValidation.stop){
-      this.payload.formValidation.stop = 0
+    if (!this.payload.formValidation.stop) {
+      this.payload.formValidation.stop = 0;
     }
     return this.payload.formValidation.stop;
   }
 
   set stop(value) {
-    console.log("stop value", value);
+    console.log('stop value', value);
     if (this.stop < value) {
       this.payload.formValidation.stop = value;
-    } 
+    }
   }
 
   get missingFields() {
@@ -472,7 +472,7 @@ class Ringdown {
       end: 7,
     };
     this.stop = fieldPosition[this.currentField];
-    console.log("stop", this.stop, fieldPosition[this.currentField]);
+    console.log('stop', this.stop, fieldPosition[this.currentField]);
 
     for (let i = 0; i < this.stop; i += 1) {
       console.log('fields', fields[i], i);


### PR DESCRIPTION
@abmcbride1 @abmcbride5 I spent some time thinking about the form validation flow and wrote up a rough idea on how to simplify it. The idea is:
- We keep all of the state needed for validations in a dictionary of `PatientFieldData` objects
- When a user interacts with a `FormInput` component, we run our validation logic which will update the dictionary of `PatientFieldData` objects.
- Finally, we wire up the styling of the `FormInput` components to depend on our dictionary of `PatientFieldData` objects.

This is a rough implementation for the first 3 form fields. The validation logic works, but there's a bug in which the UI isn't saving the values entered into the form inputs. I can fix that if we decide we like this approach.

Let me know what you think...  I feel like there's definitely room to improve / simplify