### PR TITLE
[Fix #149] Use tabular figures to prevent clock text from shifting around as time changes

### DIFF
--- a/src/Components/Header.scss
+++ b/src/Components/Header.scss
@@ -27,4 +27,5 @@
   margin: 0;
   padding: 0.5rem 1.5rem 0;
   text-align: right;
+  font-feature-settings: "tnum" 1;
 }


### PR DESCRIPTION
Add `font-feature-settings: "tnum" 1;` to header style to use tabular figures in the clock, so all the numbers are the same width.