### PR TITLE
Add base.scss for importing into react components

### DIFF
--- a/src/Admin/AdminNavigation.scss
+++ b/src/Admin/AdminNavigation.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
+@import '../../theme/base';
 
 .admin-navigation {
   border-bottom: 1px solid color($theme-color-base-lighter);

--- a/src/Components/Alert.scss
+++ b/src/Components/Alert.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
+@import '../../theme/base';
 
 .alert {
   background-color: rgba(0, 0, 0, 0.15);

--- a/src/Components/Counter.scss
+++ b/src/Components/Counter.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .counter {
   align-items: center;

--- a/src/Components/Drawer.scss
+++ b/src/Components/Drawer.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .drawer__content {
   display: none;

--- a/src/Components/FormRadioFieldSet.scss
+++ b/src/Components/FormRadioFieldSet.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .form-radio-field-set {
   padding: 1rem 0;

--- a/src/Components/Header.scss
+++ b/src/Components/Header.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .header {
   position: sticky;

--- a/src/Components/Heading.scss
+++ b/src/Components/Heading.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .heading {
   display: flex;

--- a/src/Components/RingdownCard.scss
+++ b/src/Components/RingdownCard.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .ringdown-card {
   background-color: white;

--- a/src/Components/RingdownDetails.scss
+++ b/src/Components/RingdownDetails.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .ringdown-details {
   background: color($theme-color-base-lightest);

--- a/src/Components/TabBar.scss
+++ b/src/Components/TabBar.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .tabbar {
   border-top: 1px solid color($theme-color-primary-darker);

--- a/src/EMS/HospitalStatusHeader.scss
+++ b/src/EMS/HospitalStatusHeader.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
+@import '../../theme/base';
 
 $rotation-deg: 60deg;
 

--- a/src/EMS/HospitalStatusRow.scss
+++ b/src/EMS/HospitalStatusRow.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-color';
-@import '../../theme/uswds-theme-custom-mixins';
+@import '../../theme/base';
 
 $row-height: 6rem;
 

--- a/src/EMS/RingdownStatus.scss
+++ b/src/EMS/RingdownStatus.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-color';
-@import '../../theme/uswds-theme-custom-mixins';
+@import '../../theme/base';
 
 .ringdownstatus__label {
   color: color($theme-color-base-light);

--- a/src/ER/Beds.scss
+++ b/src/ER/Beds.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
+@import '../../theme/base';
 
 .beds .heading {
   border-bottom: 0;

--- a/src/ER/RingdownSection.scss
+++ b/src/ER/RingdownSection.scss
@@ -1,6 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-custom-mixins';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 .ringdown-section + .ringdown-section {
   border-top: 1px solid color($theme-color-base-light);

--- a/src/ER/UnconfirmedRingdowns.scss
+++ b/src/ER/UnconfirmedRingdowns.scss
@@ -1,5 +1,4 @@
-@import '~uswds/dist/scss/packages/required';
-@import '../../theme/uswds-theme-color';
+@import '../../theme/base';
 
 body > .grid-container > .grid-row > div > #root {
   display: flex;

--- a/theme/base.scss
+++ b/theme/base.scss
@@ -1,0 +1,5 @@
+$theme-show-notifications: false;
+
+@import '../node_modules/uswds/dist/scss/packages/required';
+@import 'uswds-theme-custom-mixins';
+@import 'uswds-theme-color';


### PR DESCRIPTION
- Set `$theme-show-notifications` to false before importing `required.scss`, so that the USWDS changelog notifications aren't spammed to the console on every component import.  (That's currently 16 times on every build.)
- Also import the mixins and color files so that only one import is needed in each component's .scss file.

I don't know if `base.scss` is the best name, so happy to change it to something else. 
