### PR TITLE
[Fix #161] Put header above combobox components

### DIFF
--- a/src/Components/Header.scss
+++ b/src/Components/Header.scss
@@ -3,7 +3,7 @@
 .header {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 1000;
   background-color: color($theme-color-primary-dark);
   color: white;
 }


### PR DESCRIPTION
Change the header's `z-index` to 1000.

After:

![image](https://user-images.githubusercontent.com/61631/177637438-9ba4577b-1eee-46a1-9601-dfdabf67055b.png)
