### PR TITLE
Refactor login.js to enable Login by default

### DIFF
--- a/public/scripts/login.js
+++ b/public/scripts/login.js
@@ -1,80 +1,62 @@
+const loginForm = document.getElementById('login');
 const email = document.getElementById('email');
 const password = document.getElementById('password');
 const submitButton = document.querySelector('button[type="submit"]');
 
-const errorHTML = `<span class="usa-error-message"><i class="fas fa-exclamation-circle"></i> This is a required section</span>`;
-const successHTML = `<span class="usa-success-message"><i class="fas fa-check-circle"></i> Success</span>`;
-
-function isValidEmail() {
-  const emailParts = email.value.split('@');
-  return email.value !== '' && emailParts.length === 2;
-}
-
-function isValidPassword() {
-  return password.value !== '';
-}
+const errorHTML = `<span class="usa-error-message"><i class="fas fa-exclamation-circle"></i> This is a required field</span>`;
+const inputErrorClass = 'usa-input--error';
+const labelErrorClass = 'usa-label--error';
 
 function isValid() {
-  return isValidEmail() && isValidPassword();
+  return email.value && password.value;
 }
 
-function onFocus(event) {
-  const input = event.target;
+function updateErrorState(input) {
   const label = input.previousElementSibling;
-  label.classList.add('usa-label--focused');
-}
-
-function validate(input, label, validator) {
-  if (validator()) {
-    // if previously in error, show success
-    if (input.classList.contains('usa-input--error')) {
-      label.classList.remove('usa-label--error');
-      input.classList.remove('usa-input--error');
+  if (input.value) {
+    // if previously in error, remove that state
+    if (input.classList.contains(inputErrorClass)) {
+      label.classList.remove(labelErrorClass);
+      input.classList.remove(inputErrorClass);
       input.nextElementSibling.remove();
-      label.classList.add('usa-label--success');
-      input.classList.add('usa-input--success');
-      input.insertAdjacentHTML('afterend', successHTML);
     }
   } else {
     // show error
-    label.classList.remove('usa-label--success');
-    input.classList.remove('usa-input--success');
     if (input.nextElementSibling) {
       input.nextElementSibling.remove();
     }
-    label.classList.add('usa-label--error');
-    input.classList.add('usa-input--error');
+    label.classList.add(labelErrorClass);
+    input.classList.add(inputErrorClass);
     input.insertAdjacentHTML('afterend', errorHTML);
   }
 }
 
-function onInput(validator) {
-  return function onInputInternal(event) {
-    const input = event.target;
-    const label = input.previousElementSibling;
-    // validate on input only if was already previously in error/success
-    if (input.classList.contains('usa-input--error') || input.classList.contains('usa-input--success')) {
-      validate(input, label, validator);
-    }
-    // validate form overall for submit button
-    submitButton.disabled = !isValid();
-  };
+function handleValidationEvent(event) {
+  const input = event.target;
+  const label = input.previousElementSibling;
+  // update the label's focused state
+  label.classList[event.type === 'blur' ? 'remove' : 'add']('usa-label--focused');
+  // update the class on input event only if the element is in the error state
+  if (event.type === 'blur' || (event.type === 'input' && input.classList.contains(inputErrorClass))) {
+    updateErrorState(input);
+  }
+  // validate form overall for submit button
+  submitButton.disabled = !isValid();
 }
 
-function onBlur(validator) {
-  return function onBlurInternal(event) {
-    const input = event.target;
-    const label = input.previousElementSibling;
-    label.classList.remove('usa-label--focused');
-    validate(input, label, validator);
-    submitButton.disabled = !isValid();
-  };
+function onSubmit(event) {
+  if (!isValid()) {
+    updateErrorState(email);
+    updateErrorState(password);
+    submitButton.disabled = true;
+    event.preventDefault();
+  }
 }
 
-email.addEventListener('focus', onFocus);
-email.addEventListener('input', onInput(isValidEmail));
-email.addEventListener('blur', onBlur(isValidEmail));
+[email, password].forEach((el) => {
+  ['focus', 'input', 'blur'].forEach((type) => {
+    el.addEventListener(type, handleValidationEvent);
+  });
+});
 
-password.addEventListener('focus', onFocus);
-password.addEventListener('input', onInput(isValidPassword));
-password.addEventListener('blur', onBlur(isValidPassword));
+loginForm.addEventListener('submit', onSubmit);

--- a/views/auth/local/login.ejs
+++ b/views/auth/local/login.ejs
@@ -12,16 +12,16 @@
           </div>
         </div>
       <% } %>
-      <form method="post" action="/auth/local/login" class="usa-form">
+      <form method="post" action="/auth/local/login" id="login" class="usa-form">
         <div class="usa-form-group margin-bottom-4">
           <label for="username" class="usa-label usa-label--required">Email</label>
           <input type="email" id="email" name="username" value="<%= locals.username %>" placeholder="name@email.com" class="usa-input" />
         </div>
         <div class="usa-form-group margin-bottom-1">
           <label for="password" class="usa-label usa-label--required">Password</label>
-          <input type="password" name="password" class="usa-input" id="password" />
+          <input type="password" id="password" name="password" class="usa-input" />
         </div>
-        <button disabled class="usa-button margin-0 width-full" type="submit">Login</button>
+        <button type="submit" class="usa-button margin-0 width-full">Login</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
- Leave the Login button enabled on page load, so that it's clickable when there are auto-filled values.
- Validate the fields on Login mousedown, so that clicking it with empty fields will show an error state instead of submitting the form.
- Don't show the "Success!" message on the fields, since it seems weird to claim success before the login happens.

There's no clean way to detect the auto-filled username/password, since they don't get inserted into the DOM until [the user interacts with the page](https://stackoverflow.com/a/62199697/4200446).  So it's simplest to leave the Login button enabled by default, and then disable it and show an error if the user clicks without filling everything in.  This seems to be what most login UIs do.

**Before:**

![image](https://user-images.githubusercontent.com/61631/178063537-15ef6c60-2f93-47a0-805a-03b82d81c795.png)

**After:**

![image](https://user-images.githubusercontent.com/61631/178063563-8b0b081c-be18-48ec-b92c-2af09bcb0341.png)

**After clicking Login with no auto-fill:**

![image](https://user-images.githubusercontent.com/61631/178063744-9d81d579-cfcf-409a-8dc2-13243949572c.png)
