### PR TITLE
Remove background from checkbox and radio button components

### DIFF
--- a/theme/_uswds-theme-custom-styles.scss
+++ b/theme/_uswds-theme-custom-styles.scss
@@ -286,6 +286,12 @@ $spinner-border-width-sm: 0.2em;
   }
 }
 
+// remove the white background that USWDS puts behind the checkbox/radio component
+.usa-checkbox,
+.usa-radio {
+  background: none;
+}
+
 .usa-checkbox__label,
 .usa-radio__label {
   margin-top: 1.5rem;


### PR DESCRIPTION
The .usa-checkbox and .usa-radio styles have a white background set in USWDS, which then blocks the error and success background colors.

**Before**

![image](https://user-images.githubusercontent.com/61631/178857556-747d8a57-bf31-483c-b40d-f62f8a64484e.png)

**After**

![image](https://user-images.githubusercontent.com/61631/178857599-daea3f8f-dfb3-450a-99b3-b46f5a0634fa.png)
