### PR TITLE
Move the static routes before the cookie session and logger setup

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,17 @@ app.set('trust proxy', 1);
 app.set('view engine', 'ejs');
 app.use(expressLayouts);
 
+// set up the static routes before the logger to reduce console noise
+app.use(express.static(path.join(__dirname, 'build'), { index: false }));
+app.use(express.static(path.join(__dirname, 'public'), { index: false }));
+app.use('/libraries/fontawesome-free', express.static(path.join(__dirname, 'node_modules/@fortawesome/fontawesome-free')));
+app.use('/libraries/uswds/theme', express.static(path.join(__dirname, 'node_modules/uswds/dist')));
+
+if (process.env.NODE_ENV !== 'production') {
+  // for theme css sourcemap debugging only
+  app.use('/theme', express.static(path.join(__dirname, 'theme')));
+  app.use('/node_modules/uswds/dist', express.static(path.join(__dirname, 'node_modules/uswds/dist')));
+}
 if (process.env.NODE_ENV === 'production') {
   app.use((req, res, next) => {
     if (req.secure) {
@@ -37,16 +48,6 @@ app.use(app.sessionParser);
 app.use(passport.initialize());
 app.use(passport.session());
 
-app.use(express.static(path.join(__dirname, 'build'), { index: false }));
-app.use(express.static(path.join(__dirname, 'public'), { index: false }));
-
-app.use('/libraries/fontawesome-free', express.static(path.join(__dirname, 'node_modules/@fortawesome/fontawesome-free')));
-app.use('/libraries/uswds/theme', express.static(path.join(__dirname, 'node_modules/uswds/dist')));
-if (process.env.NODE_ENV !== 'production') {
-  // for theme css sourcemap debugging only
-  app.use('/theme', express.static(path.join(__dirname, 'theme')));
-  app.use('/node_modules/uswds/dist', express.static(path.join(__dirname, 'node_modules/uswds/dist')));
-}
 app.use('/', require('./routes'));
 
 app.get('/*', isAuthenticated, (req, res) => {


### PR DESCRIPTION
This reduces console noise during development.