### PR TITLE
Add non-breaking space before the diastolic field

### DIFF
--- a/src/EMS/PatientFields.js
+++ b/src/EMS/PatientFields.js
@@ -180,6 +180,7 @@ function PatientFields({ ringdown, onChange }) {
               max={getRange('systolicBloodPressure', 'max')}
               value={ringdown.systolicBloodPressure}
             >
+              <span className="usa-hint usa-hint--unit">&nbsp;&nbsp;</span>
               <FormInput
                 onChange={handleUserInput}
                 isWrapped={false}


### PR DESCRIPTION
Bit of a kludge, but the FormInput component already uses nbsp before the unit text, so this just puts the same spacing after the field.

**Before**

![image](https://user-images.githubusercontent.com/61631/179372635-79d16d08-2a8b-4ad1-94c7-edde0b7b3deb.png)

**After**

![image](https://user-images.githubusercontent.com/61631/179372639-6e1c5def-bfb0-4560-9761-4817e449adc2.png)
