### PR TITLE
Add `DATABASE_LOGGING` env variable to control sql logging

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,18 +1,31 @@
-process.env.DATABASE_TEST_URL = `${process.env.DATABASE_URL}_test`;
+const { NODE_ENV, DATABASE_LOGGING, DATABASE_URL } = process.env;
+const loggingByEnv = {
+  development: true,
+  test: false,
+  production: false,
+};
+const logging =
+  typeof DATABASE_LOGGING === 'string' && DATABASE_LOGGING
+    ? DATABASE_LOGGING === 'true'
+    : // if the key is undefined or empty, set logging based on the environment
+      loggingByEnv[NODE_ENV];
+
+process.env.DATABASE_TEST_URL = `${DATABASE_URL}_test`;
 
 module.exports = {
   development: {
+    logging,
     use_env_variable: 'DATABASE_URL',
     dialect: 'postgres',
   },
   test: {
+    logging,
     use_env_variable: 'DATABASE_TEST_URL',
-    logging: false,
     dialect: 'postgres',
   },
   production: {
+    logging,
     use_env_variable: 'DATABASE_URL',
-    logging: false,
     dialect: 'postgres',
     dialectOptions: {
       ssl: {

--- a/example.env
+++ b/example.env
@@ -1,5 +1,6 @@
 BASE_URL=http://localhost:3000
 DATABASE_URL=postgres://postgres@db/bats
+DATABASE_LOGGING=
 HOST=0.0.0.0
 PORT=3000
 PR_CLIENT_ID=replaceme

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,9 +3054,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035:
-  version "1.0.30001035"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz#2bb53b8aa4716b2ed08e088d4dc816a5fe089a1e"
-  integrity sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==
+  version "1.0.30001373"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz"
+  integrity sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- In the dev environment, database logging is on by default.  Setting `DATABASE_DEV_LOGGING` to `false` can clean up the console logs when debugging other things.
- Add flag to example.env.
- Update browserslist database.