### PR TITLE
Add confirmation dialog when clearing the form

### DIFF
--- a/src/Components/Alert.scss
+++ b/src/Components/Alert.scss
@@ -26,6 +26,12 @@
       @include u-margin-right(0.5);
       @include u-margin-bottom(0.5);
     }
+
+    // the custom styles file sets a 2rem top margin on buttons in a form, so reset that in case the
+    // alert is rendered inside a form
+    .usa-button {
+      margin-top: unset;
+    }
   }
 }
 

--- a/src/EMS/RingdownForm.js
+++ b/src/EMS/RingdownForm.js
@@ -18,6 +18,7 @@ function RingdownForm({ className }) {
   const { ringdowns, setRingdowns } = useContext(Context);
   const [ringdown, setRingdown] = useState(new Ringdown());
   const [step, setStep] = useState(0);
+  const [showConfirmClear, setShowConfirmClear] = useState(false);
   const [showConfirmRedirect, setShowConfirmRedirect] = useState(false);
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
 
@@ -30,7 +31,7 @@ function RingdownForm({ className }) {
   }
 
   function clear() {
-    setRingdown(new Ringdown());
+    setShowConfirmClear(true);
   }
 
   function send() {
@@ -51,6 +52,17 @@ function RingdownForm({ className }) {
     ringdown[property] = value;
     ringdown.validatePatientFields(property, value);
     setRingdown(new Ringdown(ringdown.payload, ringdown.validationData));
+  }
+
+  function handleConfirmClear() {
+    setRingdown(new Ringdown());
+    setShowConfirmClear(false);
+    // scroll the HTML element to the top to show the user the form has been cleared
+    document.documentElement.scrollTop = 0;
+  }
+
+  function handleCancelClear() {
+    setShowConfirmClear(false);
   }
 
   function handleEditForm() {
@@ -130,13 +142,24 @@ function RingdownForm({ className }) {
               </>
             )}
           </fieldset>
+          {showConfirmClear && (
+            <Alert
+              type="warning"
+              title="Clear form?"
+              message="All of the fields will be reset."
+              destructive="Clear form"
+              cancel="Keep editing"
+              onDestructive={handleConfirmClear}
+              onCancel={handleCancelClear}
+            />
+          )}
           {showConfirmRedirect && (
             <Alert
               type="success"
               title="Hospital notified"
               message="Please select a new destination."
-              cancel="Edit ringdown"
               primary="Return to hospital list"
+              cancel="Edit ringdown"
               onPrimary={handleConfirmRedirect}
               onCancel={handleEditForm}
             />


### PR DESCRIPTION
- Fix #188.
- Scroll to the top of the form after clearing it to show that the ringdown has been reset.
- Reset margin-top on the alert buttons so they render correctly when nested inside a form.

This is rebased on #193 so that the buttons are laid out correctly.

@cleneman, note that the buttons are stacked, which seems to be the default for this alert component.  

### After

![image](https://user-images.githubusercontent.com/61631/182727203-986ce080-65ac-40b7-89d6-691eb7757ec7.png)
