### PR TITLE
Make new ringdown modal the full height of the window

### DIFF
--- a/src/Components/Header.scss
+++ b/src/Components/Header.scss
@@ -1,12 +1,18 @@
 @import '../../theme/base';
 
 .header {
-  top: 0;
   @include u-padding(2);
   background-color: white;
+  height: units(15);
   position: sticky;
+  top: 0;
+  width: 100%;
   z-index: 1000;
   box-shadow: 0 6px 6px -6px rgba(0, 0, 0, 0.1);
+}
+
+html.no-scrolling .header {
+  position: fixed;
 }
 
 .header__logo {

--- a/src/Components/Header.scss
+++ b/src/Components/Header.scss
@@ -11,10 +11,6 @@
   box-shadow: 0 6px 6px -6px rgba(0, 0, 0, 0.1);
 }
 
-html.no-scrolling .header {
-  position: fixed;
-}
-
 .header__logo {
   height: units(2);
   user-select: none;

--- a/src/ER/ER.js
+++ b/src/ER/ER.js
@@ -73,6 +73,14 @@ export default function ER() {
     }
   }, [lastMessage, setRingdowns, setUnconfirmedRingdowns, setStatusUpdate, showRingdown, playSound]);
 
+  useEffect(() => {
+    if (hasUnconfirmedRingdowns) {
+      document.documentElement.classList.add('no-scrolling');
+    } else {
+      document.documentElement.classList.remove('no-scrolling');
+    }
+  }, [hasUnconfirmedRingdowns]);
+
   return (
     <div className="grid-container">
       <div className="grid-row">

--- a/src/ER/ER.js
+++ b/src/ER/ER.js
@@ -82,7 +82,7 @@ export default function ER() {
   }, [hasUnconfirmedRingdowns]);
 
   return (
-    <div className="grid-container">
+    <div className="grid-container minh-100vh">
       <div className="grid-row">
         <div className="tablet:grid-col-6 tablet:grid-offset-3">
           <RoutedHeader selectedTab={selectedTab} onSelect={setSelectedTab} />

--- a/src/ER/UnconfirmedRingdowns.scss
+++ b/src/ER/UnconfirmedRingdowns.scss
@@ -7,7 +7,7 @@ body > .grid-container > .grid-row > div > #root {
 }
 
 .unconfirmed-ringdowns {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;

--- a/src/ER/UnconfirmedRingdowns.scss
+++ b/src/ER/UnconfirmedRingdowns.scss
@@ -22,8 +22,11 @@ body > .grid-container > .grid-row > div > #root {
 .unconfirmed-ringdowns__container {
   background-color: white;
   border-radius: 1rem 1rem 0 0;
-  max-height: 90%;
+  // the Header is 7.5rem high, so leave a little space between it and the ringdown container
+  max-height: calc(100vh - 8rem);
   padding: 1.25rem;
+  // let the overlay scroll vertically, since the body won't scroll while it's open
+  overflow-y: auto;
 
   h2 {
     text-align: center;

--- a/src/ER/UnconfirmedRingdowns.scss
+++ b/src/ER/UnconfirmedRingdowns.scss
@@ -1,22 +1,16 @@
 @import '../../theme/base';
 
-body > .grid-container > .grid-row > div > #root {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
 .unconfirmed-ringdowns {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
   background: rgba(27, 27, 27, 0.5);
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   justify-content: flex-end;
+  height: 100vh;
 }
 
 .unconfirmed-ringdowns__container {

--- a/theme/_uswds-theme-custom-styles.scss
+++ b/theme/_uswds-theme-custom-styles.scss
@@ -22,6 +22,14 @@ i.e.
 
 @import 'uswds-theme-custom-mixins';
 
+html.no-scrolling {
+  overflow: hidden;
+}
+
+html.no-scrolling body {
+  padding-top: units(15);
+}
+
 .logo {
   width: 150px;
   height: 35px;

--- a/theme/_uswds-theme-custom-styles.scss
+++ b/theme/_uswds-theme-custom-styles.scss
@@ -26,10 +26,6 @@ html.no-scrolling {
   overflow: hidden;
 }
 
-html.no-scrolling body {
-  padding-top: units(15);
-}
-
 .logo {
   width: 150px;
   height: 35px;
@@ -102,6 +98,10 @@ iframe,
 .grid-container {
   padding-left: 0;
   padding-right: 0;
+}
+
+.minh-100vh {
+  min-height: 100vh;
 }
 
 // animated spinner taken from Bootstrap


### PR DESCRIPTION
- Fix #211
- Set the header to 100vh and position: fixed.
- Add a no-scrolling class to html so the body won't scroll while the modal is open.

Adding a class to the HTML element, outside of the React tree, doesn't feel great, but it's the only way to stop the body from scrolling while the overlay is open.  I think a redesign of the incoming ringdown UI won't require this modal takeover, so this is an okay solution for now.

### Before

The incoming ringdown UI is stuck to the bottom of the list, which can be off-screen when there are enough ringdowns.

![image](https://user-images.githubusercontent.com/61631/185062793-02c4184f-4ae4-4115-883a-474aa855ff59.png)

### After

The UI is stuck to the bottom of the viewport, not the body content.

![image](https://user-images.githubusercontent.com/61631/187013117-69509d52-d045-4735-98bd-43a78104d48a.png)

The overlay will scroll if needed:

![image](https://user-images.githubusercontent.com/61631/187312000-b3fdff0e-7f4b-4a91-b3db-c07f0b16fa27.png)
