### PR TITLE
Prevent form submission on enter key if ringdown isn't valid

### DIFF
--- a/client/src/Components/Form.js
+++ b/client/src/Components/Form.js
@@ -1,6 +1,8 @@
 import React, { useMemo, useContext, createContext } from 'react';
 import PropTypes from 'prop-types';
 
+const ignoreEnterKey = (e) => e.preventDefault();
+
 const FormContext = createContext(undefined);
 
 const Form = ({ data, onChange, children, ...props }) => {
@@ -26,11 +28,14 @@ Form.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.object.isRequired,
   onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
   children: PropTypes.node,
 };
 
 Form.defaultProps = {
   onChange: null,
+  // by default, prevent pressing enter on an input from submitting the form
+  onSubmit: ignoreEnterKey,
   children: null,
 };
 

--- a/client/src/Components/Form.js
+++ b/client/src/Components/Form.js
@@ -1,8 +1,6 @@
 import React, { useMemo, useContext, createContext } from 'react';
 import PropTypes from 'prop-types';
 
-const ignoreEnterKey = (e) => e.preventDefault();
-
 const FormContext = createContext(undefined);
 
 const Form = ({ data, onChange, children, ...props }) => {
@@ -14,12 +12,19 @@ const Form = ({ data, onChange, children, ...props }) => {
     [data, onChange]
   );
 
+  function onSubmitInternal(event) {
+    event.preventDefault();
+    if (props.onSubmit) {
+      props.onSubmit(event);
+    }
+  }
+
   // we spread the extra props on the form so the caller can apply classes and other properties to
   // the form element
   return (
     <FormContext.Provider value={context}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <form {...props}>{children}</form>
+      <form {...{ ...props, onSubmit: onSubmitInternal }}>{children}</form>
     </FormContext.Provider>
   );
 };
@@ -34,8 +39,7 @@ Form.propTypes = {
 
 Form.defaultProps = {
   onChange: null,
-  // by default, prevent pressing enter on an input from submitting the form
-  onSubmit: ignoreEnterKey,
+  onSubmit: null,
   children: null,
 };
 

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -95,7 +95,7 @@ function RingdownForm({ className }) {
     setRingdowns([...ringdowns]);
   }
 
-  function onSubmit(event) {
+  function onSubmit() {
     if (ringdown.isValid) {
       if (step === 0) {
         next();

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -95,6 +95,16 @@ function RingdownForm({ className }) {
     setRingdowns([...ringdowns]);
   }
 
+  function onSubmit(event) {
+    if (!ringdown.isValid) {
+      event.preventDefault();
+    } else if (step === 0) {
+      next();
+    } else {
+      send();
+    }
+  }
+
   // prettier-ignore
   return (
     <>
@@ -102,6 +112,7 @@ function RingdownForm({ className }) {
         <Form
           data={ringdown}
           onChange={onChange}
+          onSubmit={onSubmit}
           className={classNames('usa-form', className)}
         >
           <div className="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon">

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -96,7 +96,6 @@ function RingdownForm({ className }) {
   }
 
   function onSubmit(event) {
-    event.preventDefault();
     if (ringdown.isValid) {
       if (step === 0) {
         next();

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -96,12 +96,13 @@ function RingdownForm({ className }) {
   }
 
   function onSubmit(event) {
-    if (!ringdown.isValid) {
-      event.preventDefault();
-    } else if (step === 0) {
-      next();
-    } else {
-      send();
+    event.preventDefault();
+    if (ringdown.isValid) {
+      if (step === 0) {
+        next();
+      } else {
+        send();
+      }
     }
   }
 


### PR DESCRIPTION
- Fix #226.
- If the current screen is in a valid state, then pressing enter in an input will go to the next step.
