### PR TITLE
Add dismissable prop to RingdownStatus

### DIFF
--- a/client/src/Components/RingdownCard.js
+++ b/client/src/Components/RingdownCard.js
@@ -19,7 +19,7 @@ const AcknowledgedStatus = {
   [Status.REDIRECTED]: Status.REDIRECT_ACKNOWLEDGED,
 };
 
-function RingdownCard({ children, className, ringdown, onStatusChange }) {
+function RingdownCard({ children, className, ringdown, dismissable, onStatusChange }) {
   const [isExpanded, setExpanded] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const { currentDeliveryStatus, chiefComplaintDescription, etaDateTimeLocalObj } = ringdown;
@@ -30,7 +30,10 @@ function RingdownCard({ children, className, ringdown, onStatusChange }) {
   }
 
   const canBeDismissed =
-    currentDeliveryStatus === Status.OFFLOADED || currentDeliveryStatus === Status.CANCELLED || currentDeliveryStatus === Status.REDIRECTED;
+    dismissable &&
+    (currentDeliveryStatus === Status.OFFLOADED ||
+      currentDeliveryStatus === Status.CANCELLED ||
+      currentDeliveryStatus === Status.REDIRECTED);
 
   return (
     <div
@@ -80,12 +83,14 @@ RingdownCard.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   ringdown: PropTypes.instanceOf(Ringdown).isRequired,
+  dismissable: PropTypes.bool,
   onStatusChange: PropTypes.instanceOf(Function),
 };
 
 RingdownCard.defaultProps = {
   children: undefined,
   className: undefined,
+  dismissable: true,
   onStatusChange: undefined,
 };
 

--- a/client/src/Components/RingdownCard.js
+++ b/client/src/Components/RingdownCard.js
@@ -34,6 +34,12 @@ function RingdownCard({ children, className, ringdown, dismissable, onStatusChan
     (currentDeliveryStatus === Status.OFFLOADED ||
       currentDeliveryStatus === Status.CANCELLED ||
       currentDeliveryStatus === Status.REDIRECTED);
+  const drawerTitle =
+    currentDeliveryStatus === Status.OFFLOADED ? (
+      <RingdownBadge status={currentDeliveryStatus} />
+    ) : (
+      <Timestamp className="ringdown-card__status" label="ETA:" time={etaDateTimeLocalObj} />
+    );
 
   return (
     <div
@@ -55,7 +61,7 @@ function RingdownCard({ children, className, ringdown, dismissable, onStatusChan
       )}
       {!canBeDismissed && (
         <Drawer
-          title={<Timestamp className="ringdown-card__status" label="ETA:" time={etaDateTimeLocalObj} />}
+          title={drawerTitle}
           subtitle={<div className="ringdown-card__complaint-summary">{chiefComplaintDescription}</div>}
           isOpened={isExpanded}
           onToggle={() => setExpanded(!isExpanded)}

--- a/client/src/EMS/RingdownStatus.js
+++ b/client/src/EMS/RingdownStatus.js
@@ -113,7 +113,7 @@ function RingdownStatus({ className, onStatusChange, ringdown }) {
           </fieldset>
         )}
         <fieldset className="usa-fieldset border-top border-base-lighter">
-          <RingdownCard ringdown={ringdown} />
+          <RingdownCard ringdown={ringdown} dismissable={false} />
         </fieldset>
       </div>
     </div>


### PR DESCRIPTION
Fix #225.

### Before

![image](https://user-images.githubusercontent.com/61631/192076588-5eb5403f-2d06-4f90-a2cb-bd68e66b560a.png)

### After

Once the patient is offloaded, the ringdown summary at the bottom is still expandable, rather than showing a Dismiss link like it would in the hospital view.

![image](https://user-images.githubusercontent.com/61631/192076555-0c8e69fb-c03b-48a7-81d8-a64e3dd83e5b.png)
