### PR TITLE
[Fix #212] Ensure all user data loaded before rendering interface

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,42 +7,54 @@ import EMS from './EMS';
 import ER from './ER';
 import Admin from './Admin';
 import Redirect from './Components/Redirect';
+import Spinner from './Components/Spinner';
 
 function App() {
-  const { setUser, setOrganization, setHospital, setHospitalUser } = useContext(Context);
+  const { user, setUser, setOrganization, setHospital, setHospitalUser } = useContext(Context);
 
   useEffect(() => {
     // hit the users endpoint to ensure authenticated
     ApiService.users.me().then((response) => {
       // save the user data into the context
       const user = response.data;
-      setUser(user);
       setOrganization(user.organization);
-      if (user.organization.type === 'HEALTHCARE') {
+      if (user.organization?.type === 'HEALTHCARE') {
         // TODO: handle user added to multiple hospitals
-        setHospital(user.activeHospitals[0].hospital);
-        setHospitalUser(user.activeHospitals[0]);
+        if (user.activeHospitals?.length > 0) {
+          setHospital(user.activeHospitals[0].hospital);
+          setHospitalUser(user.activeHospitals[0]);
+        }
       }
+      setUser(user);
     });
   }, [setUser, setOrganization, setHospital, setHospitalUser]);
 
   return (
-    <Router>
-      <Switch>
-        <Route path="/ems">
-          <EMS />
-        </Route>
-        <Route path="/er">
-          <ER />
-        </Route>
-        <Route path="/admin">
-          <Admin />
-        </Route>
-        <Route exact path="/">
-          <Redirect />
-        </Route>
-      </Switch>
-    </Router>
+    <>
+      {!user && (
+        <div className="padding-9">
+          <Spinner />
+        </div>
+      )}
+      {user && (
+        <Router>
+          <Switch>
+            <Route path="/ems">
+              <EMS />
+            </Route>
+            <Route path="/er">
+              <ER />
+            </Route>
+            <Route path="/admin">
+              <Admin />
+            </Route>
+            <Route exact path="/">
+              <Redirect />
+            </Route>
+          </Switch>
+        </Router>
+      )}
+    </>
   );
 }
 

--- a/client/src/Components/Redirect.js
+++ b/client/src/Components/Redirect.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
@@ -22,7 +22,7 @@ function Redirect({ isAdminOnly }) {
     }
   }, [history, user, isAdminOnly]);
 
-  return <></>;
+  return null;
 }
 
 Redirect.propTypes = {

--- a/client/src/Components/Redirect.js
+++ b/client/src/Components/Redirect.js
@@ -3,7 +3,6 @@ import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import Context from '../Context';
-import Spinner from './Spinner';
 
 function Redirect({ isAdminOnly }) {
   const { user } = useContext(Context);
@@ -23,11 +22,7 @@ function Redirect({ isAdminOnly }) {
     }
   }, [history, user, isAdminOnly]);
 
-  return (
-    <div className="padding-9">
-      <Spinner />
-    </div>
-  );
+  return <></>;
 }
 
 Redirect.propTypes = {


### PR DESCRIPTION
This changes the SPA to show a spinner until the first connection back to the server is completed and a complete set of user auth data (i.e. user, org, hospital, hospitalUser) is set in the context.
