### PR TITLE
Pull default ringdown values from query params

### DIFF
--- a/client/src/Components/FormInput.js
+++ b/client/src/Components/FormInput.js
@@ -53,7 +53,6 @@ function FormInput({
           value={value || ''}
           onKeyDown={handleKeyDown}
           onBlur={handleOnBlur}
-          valueAsNumber={type === 'number'}
           onChange={handleOnChange}
           onFocus={() => setFocused(true)}
           required={required}

--- a/client/src/EMS/EMS.js
+++ b/client/src/EMS/EMS.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { useContext, useEffect, useState } from 'react';
 import useWebSocket from 'react-use-websocket';
+import { useLocation } from 'react-router-dom';
 
 import RoutedHeader from '../Components/RoutedHeader';
 import Context from '../Context';
@@ -13,8 +14,28 @@ export default function EMS() {
   const socketUrl = `${window.location.origin.replace(/^http/, 'ws')}/wss/user`;
   const { lastMessage } = useWebSocket(socketUrl, { shouldReconnect: () => true });
   const { setRingdowns, setStatusUpdates } = useContext(Context);
-
   const [selectedTab, setSelectedTab] = useState(0);
+  const { search } = useLocation();
+  let defaultPayload;
+
+  if (search) {
+    // we use this just for its payload, since fields are mapped to different payload subobjects, depending on which model they came from
+    const rd = new Ringdown();
+
+    new URLSearchParams(search).forEach((value, key) => {
+      const field = Ringdown.Fields[key];
+
+      if (field) {
+        const typedValue = field.valueFromString(value);
+
+        if (typedValue !== undefined) {
+          rd[key] = typedValue;
+        }
+      }
+    });
+
+    defaultPayload = rd.payload;
+  }
 
   useEffect(() => {
     if (lastMessage?.data) {
@@ -29,7 +50,10 @@ export default function EMS() {
       <div className="grid-row">
         <div className="tablet:grid-col-6 tablet:grid-offset-3">
           <RoutedHeader selectedTab={selectedTab} onSelect={setSelectedTab} />
-          <RingdownForm className={classNames('tabbar-content', { 'tabbar-content--selected': selectedTab === 0 })} />
+          <RingdownForm
+            defaultPayload={defaultPayload}
+            className={classNames('tabbar-content', { 'tabbar-content--selected': selectedTab === 0 })}
+          />
           <HospitalStatuses
             onReturn={() => setSelectedTab(0)}
             className={classNames('tabbar-content', { 'tabbar-content--selected': selectedTab === 1 })}

--- a/client/src/EMS/EMS.js
+++ b/client/src/EMS/EMS.js
@@ -16,25 +16,28 @@ export default function EMS() {
   const { setRingdowns, setStatusUpdates } = useContext(Context);
   const [selectedTab, setSelectedTab] = useState(0);
   const { search } = useLocation();
-  let defaultPayload;
+  let defaultPayload = undefined;
 
-  if (search) {
-    // we use this just for its payload, since fields are mapped to different payload subobjects, depending on which model they came from
-    const rd = new Ringdown();
+  // when we're in development, pull the default payload from the URL search params
+  if (process.env.NODE_ENV === 'development') {
+    if (search) {
+      // we use this just for its payload, since fields are mapped to different payload sub-objects, depending on which model they came from
+      const rd = new Ringdown();
 
-    new URLSearchParams(search).forEach((value, key) => {
-      const field = Ringdown.Fields[key];
+      new URLSearchParams(search).forEach((value, key) => {
+        const field = Ringdown.Fields[key];
 
-      if (field) {
-        const typedValue = field.valueFromString(value);
+        if (field) {
+          const parsedValue = field.parseValueFromString(value);
 
-        if (typedValue !== undefined) {
-          rd[key] = typedValue;
+          if (parsedValue !== undefined) {
+            rd[key] = parsedValue;
+          }
         }
-      }
-    });
+      });
 
-    defaultPayload = rd.payload;
+      defaultPayload = rd.payload;
+    }
   }
 
   useEffect(() => {

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -15,9 +15,9 @@ import HospitalSelection from './HospitalSelection';
 import PatientFields from './PatientFields';
 import RingdownStatus from './RingdownStatus';
 
-function RingdownForm({ className }) {
+function RingdownForm({ defaultPayload, className }) {
   const { ringdowns, setRingdowns } = useContext(Context);
-  const [ringdown, setRingdown] = useState(new Ringdown());
+  const [ringdown, setRingdown] = useState(new Ringdown(defaultPayload));
   const [step, setStep] = useState(0);
   const [showConfirmClear, setShowConfirmClear] = useState(false);
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -46,6 +46,23 @@ function RingdownForm({ defaultPayload, className }) {
         // eslint-disable-next-line no-console
         console.log(error);
       });
+
+    // when we're in development, log a URL that can be loaded to fill out the fields with the same values that we just submitted
+    if (process.env.NODE_ENV === 'development') {
+      const params = new URLSearchParams();
+      const { host, pathname } = window.location;
+
+      Object.keys(Ringdown.Fields).forEach((key) => {
+        const value = ringdown[key];
+
+        // collect all of the non-empty/non-false fields in a set of params
+        if (value !== null && value !== undefined && (typeof value !== 'boolean' || value)) {
+          params.set(key, value);
+        }
+      });
+
+      console.log(`${host + pathname}?${params}`);
+    }
   }
 
   function onChange(property, value) {

--- a/shared/FieldMetadata.js
+++ b/shared/FieldMetadata.js
@@ -4,6 +4,7 @@ const Suffixes = {
 };
 const NonParamTypes = ['uuid', 'date'];
 const UUIDPattern = /[-a-f0-9]+/i;
+const BooleanPattern = /^true|false$/i;
 
 function createColName({ name, type }) {
   return name.toLowerCase() + (Suffixes[type] || '');
@@ -23,7 +24,7 @@ class FieldMetadata {
     );
   }
 
-  valueFromString(string) {
+  parseValueFromString(string) {
     let value;
 
     switch (this.type) {
@@ -32,12 +33,17 @@ class FieldMetadata {
         break;
 
       case 'integer':
+        value = Number(string);
+        value = Number.isInteger(value) ? value : undefined;
+        break;
+
       case 'decimal':
         value = Number(string);
+        value = Number.isFinite(value) ? value : undefined;
         break;
 
       case 'boolean':
-        value = Boolean(string);
+        value = BooleanPattern.test(string) ? Boolean(string) : undefined;
         break;
 
       case 'enum':

--- a/shared/FieldMetadata.js
+++ b/shared/FieldMetadata.js
@@ -3,6 +3,7 @@ const Suffixes = {
   enum: 'enum',
 };
 const NonParamTypes = ['uuid', 'date'];
+const UUIDPattern = /[-a-f0-9]+/i;
 
 function createColName({ name, type }) {
   return name.toLowerCase() + (Suffixes[type] || '');
@@ -20,6 +21,40 @@ class FieldMetadata {
       },
       field
     );
+  }
+
+  valueFromString(string) {
+    let value;
+
+    switch (this.type) {
+      case 'uuid':
+        value = UUIDPattern.test(string) ? string : undefined;
+        break;
+
+      case 'integer':
+      case 'decimal':
+        value = Number(string);
+        break;
+
+      case 'boolean':
+        value = Boolean(string);
+        break;
+
+      case 'enum':
+        value = this.typeArgs.includes(string) ? string : undefined;
+        break;
+
+      case 'text':
+      case 'string':
+        value = string;
+        break;
+
+      default:
+        value = undefined;
+        break;
+    }
+
+    return value;
   }
 
   toString() {


### PR DESCRIPTION
- This makes it easy to fill out the ringdown form for testing. 
- Add a `defaultPayload` prop to `RingdownForm`, and use it when creating the ringdown state. 
- Add a check for query params in `EMS`.
- Move the code to finish creating the Ringdown model class into an IIFE, so it's more clearly util code. 
- Add `valueFromString()` method to `FieldMetadata`, to make it easy to convert a string to a correctly typed value for that field.

Example URL: http://localhost:3000/ems?ambulanceIdentifier=SFFD-1&dispatchCallNumber=123&age=42&sex=MALE&stableIndicator=false&chiefComplaintDescription=bloop%20%26%20blorp%20%26%20%3Cbleep%3E&etohSuspectedIndicator=true&restraintIndicator=true&oxygenSaturation=90&lowOxygenResponseType=ROOM%20AIR&etaMinutes=7&hospitalId=a818fabd-f0a8-442a-bd0a-8fba0bac7496

After submitting the ringdown and returning to service, the new ringdown form will be blank, rather than pulling from the params, even though the URL still contains them.  This is slightly weird, but also somewhat useful, as you can enter a different ringdown without having to clear out the values.  And if you do want the defaults again, you can just refresh the page.

@francisli, curious if this looks useful to you, and whether it would be okay to have in production code, or if I should look for a way to have it only run on dev.