### PR TITLE
Refactor field handling in Ringdown.js

### DIFF
--- a/client/src/Components/Form.js
+++ b/client/src/Components/Form.js
@@ -43,7 +43,9 @@ Form.defaultProps = {
   children: null,
 };
 
-const useForm = () => {
+export default Form;
+
+export const useForm = () => {
   const context = useContext(FormContext);
 
   if (!context) {
@@ -52,7 +54,3 @@ const useForm = () => {
 
   return context;
 };
-
-export default Form;
-
-export { useForm };

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -67,7 +67,7 @@ function RingdownForm({ defaultPayload, className }) {
 
   function onChange(property, value) {
     ringdown[property] = value;
-    ringdown.validatePatientFields(property, value);
+    ringdown.validatePatientField(property, value);
     setRingdown(new Ringdown(ringdown.payload, ringdown.validationData));
   }
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   server:
-    command: bash -l -c "yarn start:dev"
+    command: bash -l -c "yarn && yarn start:dev"
     volumes:
       - .:/opt/node/app
       - /opt/node/app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:12
   server:
     build: .
-    command: bash -l -c "yarn start:prod"
+    command: bash -l -c "yarn && yarn start:prod"
     env_file:
       - .env
     ports:


### PR DESCRIPTION
- `Ringdown.Fields` was added in a previous PR, so use that instead of `fieldHashes`.
- Simplify logic in `setValidationStateForInput()`, which didn't seem to depend on the current state.
