### PR TITLE
Remove empty key/values in Ringdown class.

### DIFF
--- a/client/src/Models/Ringdown.js
+++ b/client/src/Models/Ringdown.js
@@ -258,12 +258,7 @@ class Ringdown {
           return this.payload[objectName][field.name] ?? field.defaultValue;
         },
         set(newValue) {
-          // This ensures any fields that are empty aren't sent to the backend.
-          if (newValue === '') {
-            delete this.payload[objectName][field.name];
-          } else {
-            this.payload[objectName][field.name] = newValue;
-          }
+          this.payload[objectName][field.name] = newValue;
         },
         configurable: true,
         enumerable: true,

--- a/client/src/Models/Ringdown.js
+++ b/client/src/Models/Ringdown.js
@@ -328,7 +328,12 @@ class Ringdown {
           return this.payload[objectName][field.name] ?? field.defaultValue;
         },
         set(newValue) {
-          this.payload[objectName][field.name] = newValue;
+          // This ensures any fields that are empty aren't sent to the backend.
+          if (newValue === '') {
+            delete this.payload[objectName][field.name];
+          } else {
+            this.payload[objectName][field.name] = newValue;
+          }
         },
         configurable: true,
         enumerable: true,

--- a/server/routes/api/ringdowns.js
+++ b/server/routes/api/ringdowns.js
@@ -117,6 +117,11 @@ router.post('/', middleware.isAuthenticated, async (req, res) => {
   try {
     let patientDelivery;
     let json;
+    for (let key in req.body.patient) {
+      if (req.body.patient[key] === '') {
+        req.body.patient[key] = null;
+      }
+    }
     await models.sequelize.transaction(async (transaction) => {
       const [emsCall] = await models.EmergencyMedicalServiceCall.findOrCreate({
         where: {

--- a/server/test/integration/api/ringdowns.js
+++ b/server/test/integration/api/ringdowns.js
@@ -165,6 +165,105 @@ describe('/api/ringdowns', () => {
       assert.deepStrictEqual(ambulance.UpdatedById, user.id);
     });
   });
+  // to expect an unrequired null value to
+  describe('POST /', () => {
+    const patientData = {
+      age: 30,
+      sex: 'MALE',
+      emergencyServiceResponseType: 'CODE 2',
+      chiefComplaintDescription: 'Fainted while walking home.',
+      stableIndicator: true,
+      systolicBloodPressure: 120,
+      diastolicBloodPressure: 80,
+      heartRateBpm: 70,
+      respiratoryRate: null,
+      oxygenSaturation: 98,
+      lowOxygenResponseType: 'SUPPLEMENTAL OXYGEN',
+      supplementalOxygenAmount: 2,
+      temperature: 99.4,
+      treatmentNotes: 'Gave px lollipop',
+      etohSuspectedIndicator: false,
+      drugsSuspectedIndicator: true,
+      psychIndicator: false,
+      combativeBehaviorIndicator: false,
+      restraintIndicator: false,
+      covid19SuspectedIndicator: true,
+      glasgowComaScale: 3,
+      ivIndicator: false,
+      otherObservationNotes: 'Needs assistance walking',
+    };
+
+    it('creates a ringdown accepting null value for an unrequired field', async () => {
+      await testSession
+        .post('/auth/local/login')
+        .set('Accept', 'application/json')
+        .send({ username: 'norcal.paramedic@example.com', password: 'abcd1234' })
+        .expect(HttpStatus.OK);
+
+      const response = await testSession
+        .post('/api/ringdowns')
+        .set('Accept', 'application/json')
+        .send({
+          ambulance: {
+            ambulanceIdentifier: 'NORCAL-1',
+          },
+          emsCall: {
+            dispatchCallNumber: 1234,
+          },
+          hospital: {
+            id: '00752f60-068f-11eb-adc1-0242ac120002',
+          },
+          patient: patientData,
+          patientDelivery: {
+            etaMinutes: 15,
+          },
+        })
+        .expect(HttpStatus.CREATED);
+      assert(response.body.id);
+      assert.deepStrictEqual(response.body.ambulance.ambulanceIdentifier, 'NORCAL-1');
+      assert.deepStrictEqual(response.body.emsCall.dispatchCallNumber, 1234);
+      assert.deepStrictEqual(response.body.hospital.id, '00752f60-068f-11eb-adc1-0242ac120002');
+      assert.deepStrictEqual(response.body.patient, patientData);
+      assert.deepStrictEqual(response.body.patientDelivery.currentDeliveryStatus, 'RINGDOWN SENT');
+      assert.deepStrictEqual(response.body.patientDelivery.etaMinutes, 15);
+    });
+
+    it('creates a new ambulance record as needed', async () => {
+      await testSession
+        .post('/auth/local/login')
+        .set('Accept', 'application/json')
+        .send({ username: 'norcal.paramedic@example.com', password: 'abcd1234' })
+        .expect(HttpStatus.OK);
+
+      const response = await testSession
+        .post('/api/ringdowns')
+        .set('Accept', 'application/json')
+        .send({
+          ambulance: {
+            ambulanceIdentifier: 'NEW-1',
+          },
+          emsCall: {
+            dispatchCallNumber: 1234,
+          },
+          hospital: {
+            id: '00752f60-068f-11eb-adc1-0242ac120002',
+          },
+          patient: patientData,
+          patientDelivery: {
+            etaMinutes: 15,
+          },
+        })
+        .expect(HttpStatus.CREATED);
+      assert(response.body.id);
+      assert.deepStrictEqual(response.body.ambulance.ambulanceIdentifier, 'NEW-1');
+
+      const user = await models.User.findOne({ where: { email: 'norcal.paramedic@example.com' } });
+      const ambulance = await models.Ambulance.findOne({ where: { ambulanceIdentifier: 'NEW-1' } });
+      assert(ambulance);
+      assert.deepStrictEqual(ambulance.CreatedById, user.id);
+      assert.deepStrictEqual(ambulance.UpdatedById, user.id);
+    });
+  });
 
   describe('PATCH /:id/deliveryStatus', async () => {
     it('transitions to a next valid state', async () => {

--- a/server/test/integration/api/ringdowns.js
+++ b/server/test/integration/api/ringdowns.js
@@ -165,7 +165,7 @@ describe('/api/ringdowns', () => {
       assert.deepStrictEqual(ambulance.UpdatedById, user.id);
     });
   });
-  // to expect an unrequired null value to
+
   describe('POST /', () => {
     const patientData = {
       age: 30,


### PR DESCRIPTION
The problem this is solving is for the case of filling out a non required field, then deleting the value (possibly the user had mistaken the input they were filling in). When I added a value to BP, then deleted it, the field still existed with an empty string. The backend then tried to store the empty string in the DB, but the bp columns are expecting a smallint.