### PR TITLE
Update RingdownForm.js

### DIFF
--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -139,9 +139,10 @@ function RingdownForm({ defaultPayload, className }) {
               </p>
             </div>
           </div>
-          {step === 0 && <PatientFields onChange={onChange} ringdown={ringdown} />}
-          {step === 1 && <HospitalSelection onChange={onChange} ringdown={ringdown} />}
+         
+
           <fieldset className="usa-fieldset border-top border-base-lighter">
+            {step === 0 && <PatientFields onChange={onChange} ringdown={ringdown} />}
             {step === 0 && (
               <>
                 <button disabled={!ringdown.isPatientValid} className="usa-button width-full" type="button" onClick={next}>
@@ -152,6 +153,7 @@ function RingdownForm({ defaultPayload, className }) {
                 </button>
               </>
             )}
+            {step === 1 && <HospitalSelection onChange={onChange} ringdown={ringdown} />}
             {step === 1 && (
               <>
                 <button disabled={!ringdown.isValid} className="usa-button width-full" type="button" onClick={send}>

--- a/client/src/EMS/RingdownForm.js
+++ b/client/src/EMS/RingdownForm.js
@@ -139,12 +139,10 @@ function RingdownForm({ defaultPayload, className }) {
               </p>
             </div>
           </div>
-         
-
           <fieldset className="usa-fieldset border-top border-base-lighter">
-            {step === 0 && <PatientFields onChange={onChange} ringdown={ringdown} />}
             {step === 0 && (
               <>
+                <PatientFields onChange={onChange} ringdown={ringdown} />
                 <button disabled={!ringdown.isPatientValid} className="usa-button width-full" type="button" onClick={next}>
                   Select Hospital
                 </button>
@@ -153,9 +151,9 @@ function RingdownForm({ defaultPayload, className }) {
                 </button>
               </>
             )}
-            {step === 1 && <HospitalSelection onChange={onChange} ringdown={ringdown} />}
             {step === 1 && (
               <>
+                <HospitalSelection onChange={onChange} ringdown={ringdown} />
                 <button disabled={!ringdown.isValid} className="usa-button width-full" type="button" onClick={send}>
                   Send Ringdown
                 </button>


### PR DESCRIPTION
- https://github.com/sfbrigade/bats-server/issues/242

Reformatted how the Field/Selection components were structured

When the SelectHospital button is selected, the focus jumps to the buttons and seems to remain there for the newly rendered components.

Currently, it is set up as:
{(Step 0) render }
{(Step 1) render }

{(Step 0) render }
{(Step 1) render }

A solution may be to restructure the Step 0s together, then the Step 1s together.

{(Step 0) render }
{(Step 0) render }

{(Step 1) render }
{(Step 1) render }

Therefore, when the Select Hospital Button is clicked, the next tab will naturally be the Hospital Selections without having to mess with tabIndex. Unsure if there are any unintended consequences with this, but everything seems to work fine on my side.