### PR TITLE
Pelumi/feat/add mfa to data model

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "workspaces": [
     "client",
     "server",
+    "shared",
     "e2e",
     "user-guides"
   ],

--- a/server/migrations/20230429013050-modify_organization_add_mfa_field.js
+++ b/server/migrations/20230429013050-modify_organization_add_mfa_field.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    await queryInterface.addColumn(
+      'organization', 
+      'isMfaEnabled',
+      {
+        type: Sequelize.DataTypes.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      }
+    )
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    await queryInterface.removeColumn('isMfaEnabled')
+  }
+};

--- a/server/migrations/20230429013050-modify_organization_add_mfa_field.js
+++ b/server/migrations/20230429013050-modify_organization_add_mfa_field.js
@@ -23,6 +23,6 @@ module.exports = {
      * Example:
      * await queryInterface.dropTable('users');
      */
-    await queryInterface.removeColumn('ismfaenabled');
+    await queryInterface.removeColumn('organization', 'ismfaenabled');
   },
 };

--- a/server/migrations/20230429013050-modify_organization_add_mfa_field.js
+++ b/server/migrations/20230429013050-modify_organization_add_mfa_field.js
@@ -11,7 +11,7 @@ module.exports = {
      */
     await queryInterface.addColumn(
       'organization', 
-      'isMfaEnabled',
+      'ismfaenabled',
       {
         type: Sequelize.DataTypes.BOOLEAN,
         defaultValue: false,
@@ -27,6 +27,6 @@ module.exports = {
      * Example:
      * await queryInterface.dropTable('users');
      */
-    await queryInterface.removeColumn('isMfaEnabled')
+    await queryInterface.removeColumn('ismfaenabled')
   }
 };

--- a/server/migrations/20230429013050-modify_organization_add_mfa_field.js
+++ b/server/migrations/20230429013050-modify_organization_add_mfa_field.js
@@ -2,31 +2,27 @@
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-  async up (queryInterface, Sequelize) {
+  async up(queryInterface, Sequelize) {
     /**
      * Add altering commands here.
      *
      * Example:
      * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
      */
-    await queryInterface.addColumn(
-      'organization', 
-      'ismfaenabled',
-      {
-        type: Sequelize.DataTypes.BOOLEAN,
-        defaultValue: false,
-        allowNull: false,
-      }
-    )
+    await queryInterface.addColumn('organization', 'ismfaenabled', {
+      type: Sequelize.DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    });
   },
 
-  async down (queryInterface, Sequelize) {
+  async down(queryInterface, Sequelize) {
     /**
      * Add reverting commands here.
      *
      * Example:
      * await queryInterface.dropTable('users');
      */
-    await queryInterface.removeColumn('ismfaenabled')
-  }
+    await queryInterface.removeColumn('ismfaenabled');
+  },
 };

--- a/server/test/unit/models/organization.js
+++ b/server/test/unit/models/organization.js
@@ -18,6 +18,7 @@ describe('models.Organization', () => {
     assert(org.id);
     assert.deepStrictEqual(org.name, 'Kaiser Permanente');
     assert.deepStrictEqual(org.type, 'HEALTHCARE');
+    assert.equal(org.isMfaEnabled, false)
     assert(org.createdAt);
     assert(org.updatedAt);
 

--- a/server/test/unit/models/organization.js
+++ b/server/test/unit/models/organization.js
@@ -32,7 +32,6 @@ describe('models.Organization', () => {
 
     org.isMfaEnabled = true;
     assert.equal(org.isMfaEnabled, true);
-
   });
 
   it('creates a new Organization record with multi-factor authentication', async () => {

--- a/server/test/unit/models/organization.js
+++ b/server/test/unit/models/organization.js
@@ -18,7 +18,7 @@ describe('models.Organization', () => {
     assert(org.id);
     assert.deepStrictEqual(org.name, 'Kaiser Permanente');
     assert.deepStrictEqual(org.type, 'HEALTHCARE');
-    assert.equal(org.isMfaEnabled, false);
+    assert.deepStrictEqual(org.isMfaEnabled, false);
     assert(org.createdAt);
     assert(org.updatedAt);
 
@@ -31,7 +31,7 @@ describe('models.Organization', () => {
     assert.deepStrictEqual(updatedBy.name, 'Super User');
 
     org.isMfaEnabled = true;
-    assert.equal(org.isMfaEnabled, true);
+    assert.deepStrictEqual(org.isMfaEnabled, true);
   });
 
   it('creates a new Organization record with multi-factor authentication', async () => {
@@ -46,6 +46,6 @@ describe('models.Organization', () => {
     assert(org2.id);
     assert.deepStrictEqual(org2.name, 'Kaiser Permanente');
     assert.deepStrictEqual(org2.type, 'HEALTHCARE');
-    assert.equal(org2.isMfaEnabled, true);
+    assert.deepStrictEqual(org2.isMfaEnabled, true);
   });
 });

--- a/server/test/unit/models/organization.js
+++ b/server/test/unit/models/organization.js
@@ -18,7 +18,8 @@ describe('models.Organization', () => {
     assert(org.id);
     assert.deepStrictEqual(org.name, 'Kaiser Permanente');
     assert.deepStrictEqual(org.type, 'HEALTHCARE');
-    assert.equal(org.isMfaEnabled, false)
+    console.log('org', org);
+    assert.equal(org.isMfaEnabled, false);
     assert(org.createdAt);
     assert(org.updatedAt);
 

--- a/server/test/unit/models/organization.js
+++ b/server/test/unit/models/organization.js
@@ -29,5 +29,24 @@ describe('models.Organization', () => {
     const updatedBy = await org.getUpdatedBy();
     assert(updatedBy);
     assert.deepStrictEqual(updatedBy.name, 'Super User');
+
+    org.isMfaEnabled = true;
+    assert.equal(org.isMfaEnabled, true);
+
+  });
+
+  it('creates a new Organization record with multi-factor authentication', async () => {
+    const org2 = await models.Organization.create({
+      name: 'Kaiser Permanente',
+      type: 'HEALTHCARE',
+      CreatedById: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      UpdatedById: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      isMfaEnabled: true,
+    });
+    assert(org2);
+    assert(org2.id);
+    assert.deepStrictEqual(org2.name, 'Kaiser Permanente');
+    assert.deepStrictEqual(org2.type, 'HEALTHCARE');
+    assert.equal(org2.isMfaEnabled, true);
   });
 });

--- a/server/test/unit/models/organization.js
+++ b/server/test/unit/models/organization.js
@@ -18,7 +18,6 @@ describe('models.Organization', () => {
     assert(org.id);
     assert.deepStrictEqual(org.name, 'Kaiser Permanente');
     assert.deepStrictEqual(org.type, 'HEALTHCARE');
-    console.log('org', org);
     assert.equal(org.isMfaEnabled, false);
     assert(org.createdAt);
     assert(org.updatedAt);

--- a/shared/metadata/organization.js
+++ b/shared/metadata/organization.js
@@ -37,6 +37,12 @@ const fields = [
     defaultValue: 'PST',
   },
   {
+    name: 'isMfaEnabled',
+    type: 'boolean',
+    allowNull: false, 
+    defaultValue: false,
+  },
+  {
     name: 'isActive',
     colName: 'activeindicator',
     type: 'boolean',

--- a/shared/metadata/organization.js
+++ b/shared/metadata/organization.js
@@ -39,7 +39,7 @@ const fields = [
   {
     name: 'isMfaEnabled',
     type: 'boolean',
-    allowNull: false, 
+    allowNull: false,
     defaultValue: false,
   },
   {


### PR DESCRIPTION
For Sutter Health, we're looking to add the ability for an admin to enable two-factor authentication. 
The first step here (and in this PR) is to create an 'isMfaEnabled' column in the organization model/table that'll act as an indicator for knowing if multifactor authentication should be activated on the server side. 

Also included is an addition of the shared folder to yarn workspaces in the top level package.json

**How I tested**
Tested that:
- ismfaenabled column appears for an organization object and its default value is false
- ismfaenabled can be changed to true 
- An organization object/entry can be instantiated with a ismfaenabled value of true.