### PR TITLE
dev instructions: bring up the service in detached mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@
 3. Run:
 
    ```
-   docker compose up
+   docker compose up -d
    ```
 
    Wait a while for container images to download/build, then when everything is up
    and running, you can view the site in your browser:
 
    http://localhost:3000/
+
+   Bring the service down with `docker compose down`.
+   
 
 4. To log in to the running server container:
 


### PR DESCRIPTION
Running in detached mode frees up the terminal window when the service is up. More subjectively, it might be a little more user-friendly in terms of making it clear to the user when the service is ready -- I found myself staring at the output for a while before realizing things were ready 😅 